### PR TITLE
Add diode

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ DNS management, and that's planned.
 * [StaqLab Tunnel](https://tunnel.staqlab.com/) [![staqlab github stars badge](https://img.shields.io/github/stars/abhishekq61/tunnel-client?style=flat)](https://github.com/abhishekq61/tunnel-client/stargazers) - SSH-based. Client is open source. Server doesn't appear to be.
 * [tnnlink](https://github.com/LiljebergXYZ/tnnlink) [![tnnlink github stars badge](https://img.shields.io/github/stars/LiljebergXYZ/tnnlink?style=flat)](https://github.com/LiljebergXYZ/tnnlink/stargazers) - SSH-based. Golang. Not maintained.
 * [Telebit](https://telebit.cloud/) - Written in JS. [Code](https://git.coolaj86.com/coolaj86/telebit.js).
+* [Diode](https://diode.io/download/) - The end-to-end TLS encryption tunnel use elliptic curve secp256k1, communicate through diode blockchain node. The tunnel works with raspberry pi zero W, checkout the [demo video](https://www.youtube.com/watch?v=Zibg-6CClc4).
 
 # Commercial/Closed source
 
@@ -66,7 +67,6 @@ DNS management, and that's planned.
 * [Hoppy](https://hoppy.network/) - WireGuard-based. Provides static IPv4 and IPv6 addresses for your machines, which is a simple and useful level of abstraction. Targeted towards self-hosters and people behind NATs.
 * [gw.run](https://gw.run/) - Specifically focusing on securely exposing internal web apps to a group of people; not for publicly facing apps. Share access via email address then allow users to log in with common login providers like Google.
 * [serveo](https://serveo.net) - Mentioned quite a bit the last couple years, but appears to be down currently. Simply uses SSH for tunneling.
-
 
 # Blog posts
 


### PR DESCRIPTION
Add another tunnel option: diode

Diode is the end-to-end TLS encryption tunnel use elliptic curve secp256k1, communicate through diode blockchain node. The tunnel works with raspberry pi zero W, checkout the [demo video](https://www.youtube.com/watch?v=Zibg-6CClc4).

It's an open source project. The source code: https://github.com/diodechain/diode_go_client