### PR TITLE
Add docker-ssh-tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ the domain registration and DNS management in a simple way.
 * [Punchmole](https://github.com/Degola/punchmole/) [![punchmole github stars badge](https://img.shields.io/github/stars/Degola/punchmole?style=flat)](https://github.com/Degola/punchmole/stargazers) - Can be integrated directly into an existing Node.js project. Written in JavaScript.
 * [ephemeral-hidden-service](https://github.com/aurelg/ephemeral-hidden-service) [![ephemeral-hidden-service github stars badge](https://img.shields.io/github/stars/aurelg/ephemeral-hidden-service?style=flat)](https://github.com/aurelg/ephemeral-hidden-service/stargazers) - Create ephemeral Tor hidden services from the command line. Written in Python.
 * [netmask](https://github.com/josephdove/netmask) [![lostproxy github stars badge](https://img.shields.io/github/stars/josephdove/netmask?style=flat)](https://github.com/josephdove/netmask/stargazers) - A TCP/UDP self-hostable network tunneling solution that supports IPv4 and IPv6. Client has a GUI. MIT License. Written in Python.
+* [docker-ssh-tunnel](https://github.com/QueraTeam/docker-ssh-tunnel) [![docker-ssh-tunnel github stars badge](https://img.shields.io/github/stars/QueraTeam/docker-ssh-tunnel?style=flat)](https://github.com/QueraTeam/docker-ssh-tunnel/stargazers) - Docker images for setting up an SSH tunnel between two containers on different servers.
 
 # Commercial/Closed source
 


### PR DESCRIPTION
Hi,
Thanks for this great list of tunneling solutions.
I just wanted the simplest way to establish SSH tunnel in docker using OpenSSH, with secure default config (no shell, no root login, no custom command, ...) and auto-restart when the connection is disrupted. So I created [docker-ssh-tunnel](https://github.com/QueraTeam/docker-ssh-tunnel) which provides a server and a client image (9 and 12 MB). The images are very simple with very few lines of code.