### PR TITLE
Add tunnelite

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ the domain registration and DNS management in a simple way.
 * [Punchmole](https://github.com/Degola/punchmole/) [![punchmole github stars badge](https://img.shields.io/github/stars/Degola/punchmole?style=flat)](https://github.com/Degola/punchmole/stargazers) - Can be integrated directly into an existing Node.js project. Written in JavaScript.
 * [ephemeral-hidden-service](https://github.com/aurelg/ephemeral-hidden-service) [![ephemeral-hidden-service github stars badge](https://img.shields.io/github/stars/aurelg/ephemeral-hidden-service?style=flat)](https://github.com/aurelg/ephemeral-hidden-service/stargazers) - Create ephemeral Tor hidden services from the command line. Written in Python.
 * [netmask](https://github.com/josephdove/netmask) [![lostproxy github stars badge](https://img.shields.io/github/stars/josephdove/netmask?style=flat)](https://github.com/josephdove/netmask/stargazers) - A TCP/UDP self-hostable network tunneling solution that supports IPv4 and IPv6. Client has a GUI. MIT License. Written in Python.
+* [tunnelite](https://github.com/cristipufu/tunnelite) [![tunnelite github stars badge](https://img.shields.io/github/stars/cristipufu/tunnelite?style=flat)](https://github.com/cristipufu/tunnelite/stargazers) - A self-hostable tunneling solution for TCP, HTTP and WS connections over websockets. CLI client. MIT License. Written in .NET.
 
 # Commercial/Closed source
 


### PR DESCRIPTION
Tunneling solution, over websockets, so you don't need to expose any incoming ports in the intranet or your local machine. (CLI client, self-hostable public server).

Can tunnel tcp, http and ws requests.