### PR TITLE
Add mmar

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ the domain registration and DNS management in a simple way.
 * [ephemeral-hidden-service](https://github.com/aurelg/ephemeral-hidden-service) [![ephemeral-hidden-service github stars badge](https://img.shields.io/github/stars/aurelg/ephemeral-hidden-service?style=flat)](https://github.com/aurelg/ephemeral-hidden-service/stargazers) - Create ephemeral Tor hidden services from the command line. Written in Python.
 * [netmask](https://github.com/josephdove/netmask) [![lostproxy github stars badge](https://img.shields.io/github/stars/josephdove/netmask?style=flat)](https://github.com/josephdove/netmask/stargazers) - A TCP/UDP self-hostable network tunneling solution that supports IPv4 and IPv6. Client has a GUI. MIT License. Written in Python.
 * [tunnelite](https://github.com/cristipufu/tunnelite) [![tunnelite github stars badge](https://img.shields.io/github/stars/cristipufu/tunnelite?style=flat)](https://github.com/cristipufu/tunnelite/stargazers) - A self-hostable tunneling solution for TCP, HTTP and WS connections over websockets. CLI client. MIT License. Written in .NET.
+* [mmar](https://github.com/yusuf-musleh/mmar) [![mmar github stars badge](https://img.shields.io/github/stars/yusuf-musleh/mmar?style=flat)](https://github.com/yusuf-musleh/mmar/stargazers) - A zero-dependency, self-hostable, cross-platform HTTP tunnel that exposes your localhost to the world on a public URL. AGPL-3.0 License. Written in Go.
 
 
 # Commercial/Closed source


### PR DESCRIPTION
Hi @anderspitman, great repo!

I was wondering if I could my project [mmar](https://github.com/yusuf-musleh/mmar) to the open source section. Its a zero-dependency, self-hostable, cross-platform HTTP tunnel that exposes localhost on a public URL, written in Go.

Includes very straightforward self-hosting instructions or if you do not feel like self-hosting, you can easily create an HTTP tunnel for free on a randomly generated subdomain on "*.mmar.dev".