### PR TITLE
Add helol tunneling tool to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ the domain registration and DNS management in a simple way.
 * [Openport.io](https://openport.io) [![Openport.io github stars badge](https://img.shields.io/github/stars/openportio/openport-go?style=flat)](https://github.com/openportio/openport-go/stargazers) - Open-source client, written in Go. Supports HTTP(S) and TCP. REST Api. No account needed. Web dashboard. Also works on ESP32.
 * [Lokal.so](https://lokal.so/?ref=awesome-tunneling) HTTP/TCP/UDP Tunneling & Debugging, zero-config .local address with https, built-in S3 Server, AI Assistant, available as Desktop GUI, Web, REST API, and *CLI, available on Mac, Windows and Linux.
 * [Optimistix Tunnel](https://optimistixtunnel.com/) - Easily expose your local server to the internet with simple SSH-based tunneling. Supports HTTP(S) and TCP. No signup, no install—just connect and go. Free plan available.
+* [helol](https://github.com/Keysight/helol-Tunnel) - A stealthy covert channel leveraging the permutational properties of TLS Client-Hello packets to exfiltrate data past Next-Generation Firewalls and deep packet inspection.
 
 # Overlay networks and other advanced tools
 


### PR DESCRIPTION
Added helol to the list of tunneling tools in README.

Could not find an opensource POC.