### PR TITLE
Add rift — self-hosted QUIC tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ the domain registration and DNS management in a simple way.
 * [ephemeral-hidden-service](https://github.com/aurelg/ephemeral-hidden-service) [![ephemeral-hidden-service github stars badge](https://img.shields.io/github/stars/aurelg/ephemeral-hidden-service?style=flat)](https://github.com/aurelg/ephemeral-hidden-service/stargazers) - Create ephemeral Tor hidden services from the command line. Written in Python.
 * [TunnelAPI 1.0](https://tunnelapi.in/) [![tunnelapi github stars badge](https://img.shields.io/github/stars/vijaypurohit322/api-response-manager?style=flat)](https://github.com/vijaypurohit322/api-response-manager/stargazers) - Expose localhost to the internet. Free secure tunneling as an ngrok alternative. Appears developer focused. MIT License . Written in TypeScript.
 * [YTunnel](https://github.com/yetidevworks/ytunnel) - MIT Licensed, Rust powered, uses your domains and creates Cloudflare Tunnels with easy to use TUI [![ytunnel github stars badge](https://img.shields.io/github/stars/yetidevworks/ytunnel?style=flat)](https://github.com/yetidevworks/ytunnel)
+* [rift](https://github.com/venkatkrishna07/rift) [![rift github stars badge](https://img.shields.io/github/stars/venkatkrishna07/rift?style=flat)](https://github.com/venkatkrishna07/rift/stargazers) - Self-hosted ngrok alternative built on QUIC. Single binary, single VPS, no accounts. HTTP ,TCP and MCP tunnels with automatic Let's Encrypt, token auth, WebSockets, connection migration. MIT License. Written in Go.
 
 
 # Commercial/Closed source


### PR DESCRIPTION
rift is a self-hosted ngrok alternative built on QUIC. One binary on a VPS, one binary on the client — no accounts, no third-party in the request path.

Distinguishing features vs. other entries in the list:
- QUIC transport (TLS 1.3 in handshake, no head-of-line blocking between multiplexed tunnels, connection migration across networks)
- Single binary for both server and client
- Automatic TLS via Let's Encrypt (or pre-provisioned wildcard certs)
- HTTP subdomains + TCP port tunnels over one connection
- WebSockets work transparently

Repo: https://github.com/venkatkrishna07/rift
License: MIT