### PR TITLE
Add Shellgate

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ the domain registration and DNS management in a simple way.
 * [ephemeral-hidden-service](https://github.com/aurelg/ephemeral-hidden-service) [![ephemeral-hidden-service github stars badge](https://img.shields.io/github/stars/aurelg/ephemeral-hidden-service?style=flat)](https://github.com/aurelg/ephemeral-hidden-service/stargazers) - Create ephemeral Tor hidden services from the command line. Written in Python.
 * [TunnelAPI 1.0](https://tunnelapi.in/) [![tunnelapi github stars badge](https://img.shields.io/github/stars/vijaypurohit322/api-response-manager?style=flat)](https://github.com/vijaypurohit322/api-response-manager/stargazers) - Expose localhost to the internet. Free secure tunneling as an ngrok alternative. Appears developer focused. MIT License . Written in TypeScript.
 * [YTunnel](https://github.com/yetidevworks/ytunnel) - MIT Licensed, Rust powered, uses your domains and creates Cloudflare Tunnels with easy to use TUI [![ytunnel github stars badge](https://img.shields.io/github/stars/yetidevworks/ytunnel?style=flat)](https://github.com/yetidevworks/ytunnel)
+* [Shellgate](https://github.com/matthiastjong/shellgate) [![shellgate github stars badge](https://img.shields.io/github/stars/matthiastjong/shellgate?style=flat)](https://github.com/matthiastjong/shellgate/stargazers) - Security gateway for AI agents with SSH tunneling, MCP tool proxying, credential vault with blind-fill, human-in-the-loop approval, and audit logging. Self-hosted and Docker-ready. MIT License. Written in TypeScript.
 
 
 # Commercial/Closed source


### PR DESCRIPTION
## Summary

- Adds [Shellgate](https://github.com/matthiastjong/shellgate) to the open source section
- Shellgate is a self-hosted security gateway for AI agents that provides SSH tunneling, MCP tool proxying, credential vault with blind-fill, human-in-the-loop approval, and audit logging
- MIT licensed, Docker-ready, written in TypeScript

## Notes

Shellgate is a newer project (< 100 stars) so I understand if this doesn't meet the current threshold. It occupies a unique niche at the intersection of tunneling and AI agent security that isn't represented on the list yet. Happy to discuss or resubmit once it reaches the star requirement.