### PR TITLE
Add Broch to Commercial/Closed source

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ the domain registration and DNS management in a simple way.
 * [Openport.io](https://openport.io) [![Openport.io github stars badge](https://img.shields.io/github/stars/openportio/openport-go?style=flat)](https://github.com/openportio/openport-go/stargazers) - Open-source client, written in Go. Supports HTTP(S) and TCP. REST Api. No account needed. Web dashboard. Also works on ESP32.
 * [Lokal.so](https://lokal.so/?ref=awesome-tunneling) HTTP/TCP/UDP Tunneling & Debugging, zero-config .local address with https, built-in S3 Server, AI Assistant, available as Desktop GUI, Web, REST API, and *CLI, available on Mac, Windows and Linux.
 * [Optimistix Tunnel](https://optimistixtunnel.com/) - Easily expose your local server to the internet with simple SSH-based tunneling. Supports HTTP(S) and TCP. No signup, no install—just connect and go. Free plan available.
+* [Broch](https://broch.io/) - Self-hosted tunneling: every tunnel and HTTP request is attributed to the developer who created it, with deny-by-default policy controls and full audit trails. Traffic stays within your own infrastructure — no vendor cloud in the request path. OIDC auth (Auth0, Entra ID, Okta). Per-seat licensing with a 15-day free trial. Self-hosted via Docker; [deployment examples](https://github.com/broch-io/broch-deploy) (compose + Terraform) are MIT-licensed.
 
 # Overlay networks and other advanced tools
 


### PR DESCRIPTION
Adds [Broch](https://broch.io/) to the **Commercial/Closed source** section.

Broch is a self-hosted tunneling product aimed at teams: every tunnel and HTTP request is attributed to the developer who created it, with deny-by-default policy controls and full audit trails. Traffic stays within the operator's own infrastructure (no vendor cloud in the request path). OIDC auth (Auth0, Entra ID, Okta), per-seat licensing with a 15-day free trial, self-hosted via Docker. The [deployment examples](https://github.com/broch-io/broch-deploy) (compose + Terraform) are public and MIT-licensed.

It's a commercial offering, so per the 2026-02-16 policy note I'm submitting it under the case-by-case path rather than the 100-star threshold. Single-line addition to the existing commercial section. Happy to adjust the wording or trim it down.