### PR TITLE
Add tunnel.to

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ the domain registration and DNS management in a simple way.
 * [Openport.io](https://openport.io) [![Openport.io github stars badge](https://img.shields.io/github/stars/openportio/openport-go?style=flat)](https://github.com/openportio/openport-go/stargazers) - Open-source client, written in Go. Supports HTTP(S) and TCP. REST Api. No account needed. Web dashboard. Also works on ESP32.
 * [Lokal.so](https://lokal.so/?ref=awesome-tunneling) HTTP/TCP/UDP Tunneling & Debugging, zero-config .local address with https, built-in S3 Server, AI Assistant, available as Desktop GUI, Web, REST API, and *CLI, available on Mac, Windows and Linux.
 * [Optimistix Tunnel](https://optimistixtunnel.com/) - Easily expose your local server to the internet with simple SSH-based tunneling. Supports HTTP(S) and TCP. No signup, no install—just connect and go. Free plan available.
+* [tunnel.to](https://tunnel.to) - Managed reverse tunneling service with an open-source client. Supports custom domains, tunnel authentication, and exposing localhost applications, AI agents, and MCP servers via public HTTPS endpoints.
 
 # Overlay networks and other advanced tools
 


### PR DESCRIPTION
Tunnel.to is a managed reverse tunneling service with an open-source client that supports custom domains, tunnel authentication, and exposing localhost applications through public HTTPS endpoints.

The client repository is relatively new and does not yet meet the 100-star threshold. I’m submitting this under the commercial-service exception mentioned in the README.

Features include:

* Custom domains
* Tunnel authentication
* HTTPS endpoints
* Open-source client
* Support for localhost applications, AI agents, and MCP servers

Happy to revise the listing description if needed.