### PR TITLE
Add SteadIP to Awesome Tunneling

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ the domain registration and DNS management in a simple way.
 * [Optimistix Tunnel](https://optimistixtunnel.com/) - Easily expose your local server to the internet with simple SSH-based tunneling. Supports HTTP(S) and TCP. No signup, no install—just connect and go. Free plan available.
 * [Svix Play](https://www.svix.com/play/) [![Svix GitHub stars badge](https://img.shields.io/github/stars/svix/svix-webhooks?style=flat)](https://github.com/svix/svix-webhooks/stargazers) - Free, no-signup hosted webhook relay and debugger. Its MIT-licensed CLI exposes a local HTTP webhook endpoint at an automatically generated HTTPS URL with `svix listen URL`; intended for development rather than general-purpose production tunneling.
 * [GetPublicIP](https://getpublicip.com/) - Commercial service that routes a dedicated public IPv4/IPv6 address to a server behind NAT over WireGuard, with TCP, UDP, and ICMP support; users manage their own TLS.
+* [SteadIP](https://steadip.com/) - Offers both free and paid tunneling services. SteadIP Anchor gives your tunnel a dedicated IPv4 address, so your endpoint keeps a stable public IP instead of sharing one.
 
 # Overlay networks and other advanced tools
 


### PR DESCRIPTION
This PR adds [SteadIP](https://steadip.com/) to the awesome-tunneling list.

SteadIP is a tunneling platform for exposing local and self-hosted services to the Internet without requiring port forwarding or a public IP address.

It supports:

HTTP and HTTPS tunnels
TCP and UDP tunnels
Custom domains
Automatic SSL certificates
Multiple global gateways
CLI-based tunnel management
Self-hosted services behind NAT or CGNAT
Dedicated IPv4 address option

SteadIP is built around FRP and provides a managed interface and infrastructure for developers, homelab users, and self-hosters who need publicly accessible endpoints for local services.

Project: https://steadip.com/