### PR TITLE
Add ProxyLink to Commercial/Closed source

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ the domain registration and DNS management in a simple way.
 * [Svix Play](https://www.svix.com/play/) [![Svix GitHub stars badge](https://img.shields.io/github/stars/svix/svix-webhooks?style=flat)](https://github.com/svix/svix-webhooks/stargazers) - Free, no-signup hosted webhook relay and debugger. Its MIT-licensed CLI exposes a local HTTP webhook endpoint at an automatically generated HTTPS URL with `svix listen URL`; intended for development rather than general-purpose production tunneling.
 * [GetPublicIP](https://getpublicip.com/) - Commercial service that routes a dedicated public IPv4/IPv6 address to a server behind NAT over WireGuard, with TCP, UDP, and ICMP support; users manage their own TLS.
 
+* [ProxyLink](https://proxylink.dev/) - Exposes services behind NAT/CGNAT via HTTP/HTTPS/TCP/UDP links with automatic HTTPS, but the tunnel runs on the router or gateway rather than per-host: one WireGuard peer covers the whole LAN and any additional VLANs, so devices that can't run a client (NVRs, PBXs, managed switches) are reachable without installing anything on them. Also provides browser-based RDP, VNC and SSH sessions to those devices. Aimed at MSPs and IT teams rather than dev tunnels. Closed source, EU-hosted. Free during early access.
+
 # Overlay networks and other advanced tools
 
 * [DockFlare](https://github.com/ChrispyBacon-dev/DockFlare) [![DockFlare github stars badge](https://img.shields.io/github/stars/ChrispyBacon-dev/DockFlare?style=flat)](https://github.com/ChrispyBacon-dev/DockFlare/stargazers) - Self-hosted control plane that automates Cloudflare Tunnel, DNS, and Zero Trust Access from Docker labels and a web UI. GPL-3.0. Requires a Cloudflare account and API token. Website: https://dockflare.app


### PR DESCRIPTION
Re-raising #290, which was closed pending evidence. Apologies for the second PR, GitHub would not let me reopen the original.

You asked for an email from someone at an established company saying they use ProxyLink and trust it. That has now been sent to you directly by **Panagiotis Manousos, a systems administrator at Powertech** (https://pwrtech.gr), an IT services company in Thessaloniki, Greece. He wrote it himself and sent it from his Powertech address.

For context on the scale, since you asked whether anyone actually depends on it: Powertech have run ProxyLink in production since April across more than 70 client sites, mostly hospitality, reaching servers, PBX systems, cameras and network gear without installing an agent on each machine. Seven of their engineers use it daily.

He sent it to the address on your commits. If it has not arrived, or you would rather have the confirmation another way, say where and I will arrange it.

This branch is now up to date with master, so the diff is just the one entry. No hard feelings if it is still not a fit for the list.